### PR TITLE
Enhance multi-pair EA with risk-based sizing

### DIFF
--- a/MQL4/Experts/MultiPairSpreadEA.mq4
+++ b/MQL4/Experts/MultiPairSpreadEA.mq4
@@ -1,0 +1,164 @@
+#property strict
+#property description "Trend following multi-pair EA"
+
+input double RiskPercent  = 2.0;    // % of account balance to risk per trade
+input int    AtrPeriod     = 14;     // ATR calculation period
+input double AtrSLFactor   = 1.5;    // Stop loss multiplier
+input double AtrTPFactor   = 3.0;    // Take profit multiplier
+input int    Slippage      = 3;      // Maximum slippage
+input int    MagicNumber   = 987654; // Magic number for orders
+
+string Symbols[];
+
+int OnInit()
+{
+    int total = SymbolsTotal(true);
+    if(total <= 0)
+    {
+        Print("No symbols found in Market Watch");
+        return(INIT_FAILED);
+    }
+    ArrayResize(Symbols, total);
+    for(int i=0; i<total; i++)
+        Symbols[i] = SymbolName(i, true);
+    return(INIT_SUCCEEDED);
+}
+
+void OnTick()
+{
+    for(int i=0; i<ArraySize(Symbols); i++)
+    {
+        string symbol = Symbols[i];
+        if(!IsTradeAllowed(symbol)) continue;
+
+        double atrDaily = iATR(symbol, PERIOD_D1, AtrPeriod, 0);
+        if(atrDaily <= 0) continue;
+
+        ManageBreakeven(symbol, atrDaily);
+        if(HasOpenOrder(symbol)) continue;
+
+        int dir = TrendDirection(symbol);
+        if(dir == 0) continue;
+
+        if(EntrySignal(symbol, dir))
+            OpenTrade(symbol, dir, atrDaily);
+    }
+}
+
+int TrendDirection(string symbol)
+{
+    double weeklyClose = iClose(symbol, PERIOD_W1, 1);
+    double weeklySMA   = iMA(symbol, PERIOD_W1, 20, 0, MODE_SMA, PRICE_CLOSE, 1);
+    if(weeklyClose==0 || weeklySMA==0) return 0;
+
+    double dailyEMA20  = iMA(symbol, PERIOD_D1, 20, 0, MODE_EMA, PRICE_CLOSE, 1);
+    double dailyEMA50  = iMA(symbol, PERIOD_D1, 50, 0, MODE_EMA, PRICE_CLOSE, 1);
+
+    if(weeklyClose > weeklySMA && dailyEMA20 > dailyEMA50)
+        return 1;   // long trend
+    if(weeklyClose < weeklySMA && dailyEMA20 < dailyEMA50)
+        return -1;  // short trend
+    return 0;
+}
+
+bool EntrySignal(string symbol, int dir)
+{
+    double ma    = iMA(symbol, PERIOD_H1, 20, 0, MODE_EMA, PRICE_CLOSE, 0);
+    double price = iClose(symbol, PERIOD_H1, 0);
+    double rsi   = iRSI(symbol, PERIOD_H1, 14, PRICE_CLOSE, 0);
+    if(dir > 0)
+    {
+        if(price <= ma && rsi > 50 && rsi < 70)
+            return(true);
+    }
+    else if(dir < 0)
+    {
+        if(price >= ma && rsi < 50 && rsi > 30)
+            return(true);
+    }
+    return(false);
+}
+
+void OpenTrade(string symbol, int dir, double atrDaily)
+{
+    int    digits = (int)MarketInfo(symbol, MODE_DIGITS);
+    double price  = (dir>0) ? MarketInfo(symbol, MODE_ASK) : MarketInfo(symbol, MODE_BID);
+    double sl     = (dir>0) ? price - atrDaily*AtrSLFactor : price + atrDaily*AtrSLFactor;
+    double tp     = (dir>0) ? price + atrDaily*AtrTPFactor : price - atrDaily*AtrTPFactor;
+
+    double slDistance = MathAbs(price - sl);
+    double lot    = CalcRiskLot(symbol, slDistance);
+
+    price = NormalizeDouble(price, digits);
+    sl    = NormalizeDouble(sl, digits);
+    tp    = NormalizeDouble(tp, digits);
+
+    int type = (dir>0) ? OP_BUY : OP_SELL;
+    int ticket = OrderSend(symbol, type, lot, price, Slippage, sl, tp, "TrendEA", MagicNumber, 0);
+    if(ticket < 0)
+        Print("OrderSend failed on ", symbol, " error ", GetLastError());
+}
+
+void ManageBreakeven(string symbol, double atrDaily)
+{
+    for(int i=OrdersTotal()-1; i>=0; i--)
+    {
+        if(OrderSelect(i, SELECT_BY_POS, MODE_TRADES))
+        {
+            if(OrderSymbol()==symbol && OrderMagicNumber()==MagicNumber)
+            {
+                double open   = OrderOpenPrice();
+                double sl     = OrderStopLoss();
+                int digits    = (int)MarketInfo(symbol, MODE_DIGITS);
+                if(OrderType()==OP_BUY)
+                {
+                    if(Bid - open >= atrDaily*AtrSLFactor && sl < open)
+                        OrderModify(OrderTicket(), open, NormalizeDouble(open, digits), OrderTakeProfit(), 0);
+                }
+                else if(OrderType()==OP_SELL)
+                {
+                    if(open - Ask >= atrDaily*AtrSLFactor && sl > open)
+                        OrderModify(OrderTicket(), open, NormalizeDouble(open, digits), OrderTakeProfit(), 0);
+                }
+            }
+        }
+    }
+}
+
+bool HasOpenOrder(string symbol)
+{
+    for(int i=OrdersTotal()-1; i>=0; i--)
+    {
+        if(OrderSelect(i, SELECT_BY_POS, MODE_TRADES))
+        {
+            if(OrderSymbol()==symbol && OrderMagicNumber()==MagicNumber)
+                return(true);
+        }
+    }
+    return(false);
+}
+
+bool IsTradeAllowed(string symbol)
+{
+    return(MarketInfo(symbol, MODE_TRADEALLOWED) != 0);
+}
+
+double CalcRiskLot(string symbol, double slDistance)
+{
+    if(slDistance <= 0.0)
+        return(0.0);
+
+    double riskAmount = AccountBalance() * RiskPercent / 100.0;
+    double point      = MarketInfo(symbol, MODE_POINT);
+    double tickValue  = MarketInfo(symbol, MODE_TICKVALUE);
+
+    double lot = riskAmount / ((slDistance/point) * tickValue);
+
+    double lotStep = MarketInfo(symbol, MODE_LOTSTEP);
+    double minLot  = MarketInfo(symbol, MODE_MINLOT);
+    double maxLot  = MarketInfo(symbol, MODE_MAXLOT);
+
+    lot = MathFloor(lot/lotStep)*lotStep;
+    lot = MathMax(minLot, MathMin(lot, maxLot));
+    return(NormalizeDouble(lot, 2));
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # MT4-EA
+
+This repository contains an example MetaTrader 4 Expert Advisor designed for spread betting accounts. The EA trades every symbol visible in your Market Watch window and follows a simple trend strategy.
+
+## Expert Advisor
+
+`MQL4/Experts/MultiPairSpreadEA.mq4` automatically collects all Market Watch symbols and checks the trend on higher timeframes:
+
+1. **Weekly trend** – price relative to the 20‑period SMA.
+2. **Daily confirmation** – 20 EMA aligned above or below the 50 EMA.
+3. **Hourly entry** – price pulls back to the 20 EMA with an RSI filter.
+
+Stop loss and take profit are derived from the daily ATR (1.5× ATR for SL and 3× ATR for TP). Once price moves 1.5× ATR in profit, the stop is moved to break even. Lot size is calculated so that each trade risks **2% of the account balance** by default.
+
+## Usage
+
+1. Copy the contents of the `MQL4` folder into your MetaTrader 4 `MQL4` directory.
+2. Compile `MultiPairSpreadEA.mq4` using the MetaEditor.
+3. Attach the expert advisor to any chart. The EA will trade all Market Watch symbols using the default parameters (lot size, ATR period, etc.) which can be adjusted in the inputs.
+
+This is only a minimal example and should be tested on a demo account before any live deployment.


### PR DESCRIPTION
## Summary
- calculate lot size dynamically from 2% account risk
- document risk-based position sizing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684033a58eac83219f7b341cc75627cc